### PR TITLE
Port extension to GNOME 45

### DIFF
--- a/instantworkspaceswitcher@amalantony.net/extension.js
+++ b/instantworkspaceswitcher@amalantony.net/extension.js
@@ -18,15 +18,13 @@
 
 /* exported init */
 
-const WorkspaceAnimation = imports.ui.workspaceAnimation;
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as WorkspaceAnimation from 'resource:///org/gnome/shell/ui/workspaceAnimation.js';
 
-class Extension {
-  constructor() {
-    this.oldAnimateSwitch =
-      WorkspaceAnimation.WorkspaceAnimationController.prototype.animateSwitch;
-  }
-
+export default class DisableAnimation extends Extension {
   enable() {
+    this._oldAnimateSwitch =
+      WorkspaceAnimation.WorkspaceAnimationController.prototype.animateSwitch;
     WorkspaceAnimation.WorkspaceAnimationController.prototype.animateSwitch = function (
       _from,
       _to,
@@ -38,10 +36,6 @@ class Extension {
   }
 
   disable() {
-    WorkspaceAnimation.WorkspaceAnimationController.prototype.animateSwitch = this.oldAnimateSwitch;
+    WorkspaceAnimation.WorkspaceAnimationController.prototype.animateSwitch = this._oldAnimateSwitch;
   }
-}
-
-function init() {
-  return new Extension();
 }

--- a/instantworkspaceswitcher@amalantony.net/metadata.json
+++ b/instantworkspaceswitcher@amalantony.net/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "Disable Workspace Switch Animation for GNOME 45+",
+  "name": "Disable Workspace Switch Animation for GNOME 40+",
   "description": "Disables the workspace switch animation while preserving all other animations - instantly switch between workspaces with keyboard shortcuts.",
   "uuid": "instantworkspaceswitcher@amalantony.net",
   "shell-version": ["45"],

--- a/instantworkspaceswitcher@amalantony.net/metadata.json
+++ b/instantworkspaceswitcher@amalantony.net/metadata.json
@@ -1,7 +1,7 @@
 {
-  "name": "Disable Workspace Switch Animation for GNOME 40+",
+  "name": "Disable Workspace Switch Animation for GNOME 45+",
   "description": "Disables the workspace switch animation while preserving all other animations - instantly switch between workspaces with keyboard shortcuts.",
   "uuid": "instantworkspaceswitcher@amalantony.net",
-  "shell-version": ["40", "41", "42", "43", "44"],
+  "shell-version": ["45"],
   "url": "https://github.com/amalantony/gnome-shell-extension-instant-workspace-switcher"
 }


### PR DESCRIPTION
I used this guide: https://gjs.guide/extensions/upgrading/gnome-shell-45.html

Unfortunately, the code can't still be compatible with older GNOME versions. I don't really know how to deal with that.

closes #5 